### PR TITLE
Bump version of pymssql to 2.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "attrs==16.3.0",
         "pendulum==1.2.0",
         "singer-python==5.9.0",
-        "pymssql==2.1.5",
+        "pymssql==2.2.1",
         "backoff==1.8.0",
     ],
     entry_points="""


### PR DESCRIPTION
(Latest at time of commit)
Avoids an issue when connecting to Azure SQL databases:

pymssql.OperationalError: (20002, b'DB-Lib error message 20002, severity 9:\nAdaptive Server connection failed (xxx.database.windows.net)\nDB-Lib error message 20002, severity 9:\nAdaptive Server connection failed (xxx.database.windows.net)\n')

Issue is believed to be related to lack of SSL support in the bundled version of FreeTDS in pymssql v2.1.5