### PR TITLE
Updates to tap-mssql 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "attrs==16.3.0",
         "pendulum==1.2.0",
         "singer-python==5.9.0",
-        "pymssql==2.1.5",
+        "pymssql==2.2.1",
         "backoff==1.8.0",
     ],
     entry_points="""

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -110,7 +110,8 @@ def schema_for_column(c):
 
     elif data_type in STRING_TYPES:
         result.type = ["null", "string"]
-        result.maxLength = c.character_maximum_length
+        if c.character_maximum_length >= 0:
+            result.maxLength = c.character_maximum_length
 
     elif data_type in DATETIME_TYPES:
         result.type = ["null", "string"]

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -68,11 +68,10 @@ BYTES_FOR_INTEGER_TYPE = {
     "smallint": 2,
     "mediumint": 3,
     "int": 4,
-    "real": 4,
     "bigint": 8,
 }
 
-FLOAT_TYPES = set(["float", "double", "money"])
+FLOAT_TYPES = set(["float", "double", "money", "real"])
 
 DATETIME_TYPES = set(["datetime", "timestamp", "date", "time", "smalldatetime"])
 

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -503,7 +503,7 @@ def sync_non_binlog_streams(mssql_conn, non_binlog_catalog, config, state):
         md_map = metadata.to_map(catalog_entry.metadata)
         replication_method = md_map.get((), {}).get("replication-method")
         replication_key = md_map.get((), {}).get("replication-key")
-        primary_keys = md_map.get((), {}).get("table-key-properties")
+        primary_keys = common.get_key_properties(catalog_entry)
         LOGGER.info(f"Table {catalog_entry.table} proposes {replication_method} sync")
         if replication_method == "INCREMENTAL" and not replication_key:
             LOGGER.info(f"No replication key for {catalog_entry.table}, using full table replication")

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -71,7 +71,9 @@ BYTES_FOR_INTEGER_TYPE = {
     "bigint": 8,
 }
 
-FLOAT_TYPES = set(["float", "double", "money", "real"])
+FLOAT_TYPES = set(["float", "double", "real"])
+
+DECIMAL_TYPES = set(["decimal", "number", "money"])
 
 DATETIME_TYPES = set(["datetime", "timestamp", "date", "time", "smalldatetime"])
 
@@ -102,7 +104,7 @@ def schema_for_column(c):
         result.type = ["null", "number"]
         result.multipleOf = 10 ** (0 - (c.numeric_scale or 17))
 
-    elif data_type in ["decimal", "numeric"]:
+    elif data_type in DECIMAL_TYPES:
         result.type = ["null", "number"]
         result.multipleOf = 10 ** (0 - c.numeric_scale)
         return result
@@ -120,7 +122,11 @@ def schema_for_column(c):
         result.type = ["null", "object"]
 
     else:
-        result = Schema(None, inclusion="unsupported", description="Unsupported column type",)
+        result = Schema(
+            None,
+            inclusion="unsupported",
+            description="Unsupported column type",
+        )
     return result
 
 
@@ -135,9 +141,7 @@ def create_column_metadata(cols):
             "selected-by-default",
             schema.inclusion != "unsupported",
         )
-        mdata = metadata.write(
-            mdata, ("properties", c.column_name), "sql-datatype", c.data_type.lower()
-        )
+        mdata = metadata.write(mdata, ("properties", c.column_name), "sql-datatype", c.data_type.lower())
 
     return metadata.to_list(mdata)
 
@@ -225,9 +229,7 @@ def discover_catalog(mssql_conn, config):
         for (k, cols) in itertools.groupby(columns, lambda c: (c.table_schema, c.table_name)):
             cols = list(cols)
             (table_schema, table_name) = k
-            schema = Schema(
-                type="object", properties={c.column_name: schema_for_column(c) for c in cols}
-            )
+            schema = Schema(type="object", properties={c.column_name: schema_for_column(c) for c in cols})
             md = create_column_metadata(cols)
             md_map = metadata.to_map(md)
 
@@ -411,15 +413,12 @@ def get_non_binlog_streams(mssql_conn, catalog, config, state):
     if currently_syncing:
         currently_syncing_stream = list(
             filter(
-                lambda s: s.tap_stream_id == currently_syncing
-                and is_valid_currently_syncing_stream(s, state),
+                lambda s: s.tap_stream_id == currently_syncing and is_valid_currently_syncing_stream(s, state),
                 streams_with_state,
             )
         )
 
-        non_currently_syncing_streams = list(
-            filter(lambda s: s.tap_stream_id != currently_syncing, ordered_streams)
-        )
+        non_currently_syncing_streams = list(filter(lambda s: s.tap_stream_id != currently_syncing, ordered_streams))
 
         streams_to_sync = currently_syncing_stream + non_currently_syncing_streams
     else:
@@ -481,9 +480,7 @@ def do_sync_full_table(mssql_conn, config, catalog_entry, state, columns):
     # Prefer initial_full_table_complete going forward
     singer.clear_bookmark(state, catalog_entry.tap_stream_id, "version")
 
-    state = singer.write_bookmark(
-        state, catalog_entry.tap_stream_id, "initial_full_table_complete", True
-    )
+    state = singer.write_bookmark(state, catalog_entry.tap_stream_id, "initial_full_table_complete", True)
 
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
@@ -495,9 +492,7 @@ def sync_non_binlog_streams(mssql_conn, non_binlog_catalog, config, state):
         columns = list(catalog_entry.schema.properties.keys())
 
         if not columns:
-            LOGGER.warning(
-                "There are no columns selected for stream %s, skipping it.", catalog_entry.stream
-            )
+            LOGGER.warning("There are no columns selected for stream %s, skipping it.", catalog_entry.stream)
             continue
 
         state = singer.set_currently_syncing(state, catalog_entry.tap_stream_id)
@@ -511,9 +506,7 @@ def sync_non_binlog_streams(mssql_conn, non_binlog_catalog, config, state):
         primary_keys = md_map.get((), {}).get("table-key-properties")
         LOGGER.info(f"Table {catalog_entry.table} proposes {replication_method} sync")
         if replication_method == "INCREMENTAL" and not replication_key:
-            LOGGER.info(
-                f"No replication key for {catalog_entry.table}, using full table replication"
-            )
+            LOGGER.info(f"No replication key for {catalog_entry.table}, using full table replication")
             replication_method = "FULL_TABLE"
         if replication_method == "INCREMENTAL" and not primary_keys:
             LOGGER.info(f"No primary key for {catalog_entry.table}, using full table replication")
@@ -554,7 +547,8 @@ def log_server_params(mssql_conn):
                 cur.execute("""SELECT @@VERSION as version, @@lock_timeout as lock_wait_timeout""")
                 row = cur.fetchone()
                 LOGGER.info(
-                    "Server Parameters: " + "version: %s, " + "lock_timeout: %s, ", *row,
+                    "Server Parameters: " + "version: %s, " + "lock_timeout: %s, ",
+                    *row,
                 )
         except:
             LOGGER.warning("Encountered error checking server params. Error: (%s) %s", *e.args)

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -100,7 +100,7 @@ def schema_for_column(c):
 
     elif data_type in FLOAT_TYPES:
         result.type = ["null", "number"]
-        result.multipleOf = 10 ** (0 - (c.numeric_scale or 6))
+        result.multipleOf = 10 ** (0 - (c.numeric_scale or 17))
 
     elif data_type in ["decimal", "numeric"]:
         result.type = ["null", "number"]

--- a/tap_mssql/sync_strategies/incremental.py
+++ b/tap_mssql/sync_strategies/incremental.py
@@ -21,28 +21,20 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns):
     stream_metadata = catalog_metadata.get((), {})
 
     replication_key_metadata = stream_metadata.get("replication-key")
-    replication_key_state = singer.get_bookmark(
-        state, catalog_entry.tap_stream_id, "replication_key"
-    )
+    replication_key_state = singer.get_bookmark(state, catalog_entry.tap_stream_id, "replication_key")
 
     replication_key_value = None
 
     if replication_key_metadata == replication_key_state:
-        replication_key_value = singer.get_bookmark(
-            state, catalog_entry.tap_stream_id, "replication_key_value"
-        )
+        replication_key_value = singer.get_bookmark(state, catalog_entry.tap_stream_id, "replication_key_value")
     else:
-        state = singer.write_bookmark(
-            state, catalog_entry.tap_stream_id, "replication_key", replication_key_metadata
-        )
+        state = singer.write_bookmark(state, catalog_entry.tap_stream_id, "replication_key", replication_key_metadata)
         state = singer.clear_bookmark(state, catalog_entry.tap_stream_id, "replication_key_value")
 
     stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
     state = singer.write_bookmark(state, catalog_entry.tap_stream_id, "version", stream_version)
 
-    activate_version_message = singer.ActivateVersionMessage(
-        stream=catalog_entry.stream, version=stream_version
-    )
+    activate_version_message = singer.ActivateVersionMessage(stream=catalog_entry.stream, version=stream_version)
 
     singer.write_message(activate_version_message)
     LOGGER.info("Beginning SQL")
@@ -52,17 +44,17 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns):
             params = {}
 
             if replication_key_value is not None:
+                repl_key_clause = f"'{replication_key_value}'"
                 if catalog_entry.schema.properties[replication_key_metadata].format == "date-time":
                     replication_key_value = pendulum.parse(replication_key_value).to_iso8601_string()
+                    repl_key_clause = f"convert(datetimeoffset, '{replication_key_value}', 127)"
 
-                select_sql += " WHERE \"{}\" > convert(datetimeoffset, %(replication_key_value)s, 127) ORDER BY \"{}\" ASC".format(
-                    replication_key_metadata, replication_key_metadata
+                select_sql += (
+                    f' WHERE "{replication_key_metadata}" > {repl_key_clause} ORDER BY "{replication_key_metadata}" ASC'
                 )
 
                 params["replication_key_value"] = replication_key_value
             elif replication_key_metadata is not None:
-                select_sql += " ORDER BY \"{}\" ASC".format(replication_key_metadata)
+                select_sql += ' ORDER BY "{}" ASC'.format(replication_key_metadata)
 
-            common.sync_query(
-                cur, catalog_entry, state, select_sql, columns, stream_version, params
-            )
+            common.sync_query(cur, catalog_entry, state, select_sql, columns, stream_version, params)

--- a/tap_mssql/sync_strategies/incremental.py
+++ b/tap_mssql/sync_strategies/incremental.py
@@ -53,9 +53,9 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns):
 
             if replication_key_value is not None:
                 if catalog_entry.schema.properties[replication_key_metadata].format == "date-time":
-                    replication_key_value = pendulum.parse(replication_key_value)
+                    replication_key_value = pendulum.parse(replication_key_value).to_iso8601_string()
 
-                select_sql += " WHERE \"{}\" > %(replication_key_value)s ORDER BY \"{}\" ASC".format(
+                select_sql += " WHERE \"{}\" > convert(datetimeoffset, %(replication_key_value)s, 127) ORDER BY \"{}\" ASC".format(
                     replication_key_metadata, replication_key_metadata
                 )
 

--- a/tap_mssql/sync_strategies/incremental.py
+++ b/tap_mssql/sync_strategies/incremental.py
@@ -55,7 +55,7 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns):
                 if catalog_entry.schema.properties[replication_key_metadata].format == "date-time":
                     replication_key_value = pendulum.parse(replication_key_value)
 
-                select_sql += " WHERE \"{}\" >= %(replication_key_value)s ORDER BY \"{}\" ASC".format(
+                select_sql += " WHERE \"{}\" > %(replication_key_value)s ORDER BY \"{}\" ASC".format(
                     replication_key_metadata, replication_key_metadata
                 )
 


### PR DESCRIPTION
Changes

- Bump version of pymssql to 2.2.1 …
- Do not set the `maxLength` property of a string if the `character_maximum_length` is `-1` (indicating a "max" field)
- Move 'real' from `BYTES_FOR_INTEGER_TYPE` to `FLOAT_TYPES`
- Increase maximum scale of Number data types to 17 to allow for doubles
- Move 'money' to `DECIMAL_TYPES`
- Get `primary_keys` from `common.get_key_properties()`