### PR TITLE
add tds_version to the connection

### DIFF
--- a/tap_mssql/connection.py
+++ b/tap_mssql/connection.py
@@ -36,6 +36,7 @@ class MSSQLConnection(pymssql.Connection):
             "database": config["database"],
             "charset": "utf8",
             "port": config.get("port", "1433"),
+            "tds_version": config.get("tds_version", "8.0"),
         }
         conn = pymssql._mssql.connect(**args)
         super().__init__(conn, False, True)


### PR DESCRIPTION
Connecting to older databases e.g. MS SQL 2005, requires to set the TDS version of 7.0 in the pymssql connection.

Defaults to 8.0
