### PR TITLE
remove escape percent signs from select_sql

### DIFF
--- a/tap_mssql/sync_strategies/common.py
+++ b/tap_mssql/sync_strategies/common.py
@@ -84,12 +84,7 @@ def generate_select_sql(catalog_entry, columns):
     escaped_columns = [escape(c) for c in columns]
 
     select_sql = "SELECT {} FROM {}.{}".format(",".join(escaped_columns), escaped_db, escaped_table)
-
-    # escape percent signs
-    select_sql = select_sql.replace("%", "%%")
-    return select_sql
-
-
+    
 def row_to_singer_record(catalog_entry, version, row, columns, time_extracted):
     row_to_persist = ()
     for idx, elem in enumerate(row):

--- a/tap_mssql/sync_strategies/common.py
+++ b/tap_mssql/sync_strategies/common.py
@@ -84,7 +84,8 @@ def generate_select_sql(catalog_entry, columns):
     escaped_columns = [escape(c) for c in columns]
 
     select_sql = "SELECT {} FROM {}.{}".format(",".join(escaped_columns), escaped_db, escaped_table)
-    
+    return select_sql
+
 def row_to_singer_record(catalog_entry, version, row, columns, time_extracted):
     row_to_persist = ()
     for idx, elem in enumerate(row):


### PR DESCRIPTION
For table and column names, % should not be written as %% in a select statement.

this results in an error when a column or table has a `%` character in the name.

```
INFO syncing vw_SkiveMonthlyStatistic full table
{"type": "SCHEMA", "stream":  ..... "SURFACE_BAD_%":  ......., "key_properties": []}
{"type": "ACTIVATE_VERSION", "stream": "dbo-vw_SkiveMonthlyStatistic", "version": 1627788239240}
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.3792839050292969, "tags": {"job_type": "sync_table", "database": "dbo", "table": "vw_SkiveMonthlyStatistic", "status": "failed"}}
CRITICAL (207, b"Invalid column name 'SURFACE_BAD_%%'.DB-Lib error message 20018, severity 16:\nGeneral SQL Server error: Check messages from the SQL Server\nDB-Lib error message 20018, severity 16:\nGeneral SQL Server error: Check messages from the SQL Server\n")
```