### PR TITLE
Resolve conflicts for #25

### DIFF
--- a/MS_CDC_SETUP.md
+++ b/MS_CDC_SETUP.md
@@ -1,0 +1,460 @@
+# Setup Microsoft SQL Server Change Data Capture
+
+## Why Log Based replication
+
+Log based replication has a number of advantages over incremental key and full table replication.
+
+Some of the key features include
+1. Smaller batches of data to transfer - you are only shipping the changed data.
+2. Incremental key can't detect deletes. If the application / database has deleted records. Then you must do a full table or CDC log based replication.
+3. There is no special logic required to detect deletes. Delete records are shipped through when they occur.
+4. There is an accurate timestamp available to indicate when records are changed in the database / application.
+
+If you would like to learn more about Change Data Capture, please refer to the Microsoft Documentation below.
+
+https://docs.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server
+
+## Background
+
+Microsoft has introduced two technologies for identifying and capturing changes to tables. The first technology introduced was Change Tracking with SQL Server 2005. This inbuilt technology
+identifies rows which have changed. This approach has some downsides however as it doesn't capture the actual change data and it is a synchronous operation.
+
+Change Data Capture (CDC) was introduced with SQL Server 2016 and is a free feature if you are licensed with an Enterprise Edition. The benefit of asynchronous processing and the ability to capture a
+full image of the record is extremely useful. 
+
+## Log_Based Approach
+
+This implication of MSSQL log_based replication approach uses Change Data Capture only. It does not support Change Tracking due to the obvious limitations and performance overheads.
+
+## Setup Example
+
+The following example works with the MSSQL AdventureWorks2016 database. If you would like to try the example, please download and install the AdventureWorks database from here.
+
+https://docs.microsoft.com/en-us/sql/samples/adventureworks-install-configure
+
+Feel free to adjust a number of the steps as required (for example more restrictive privileges, database ownership, files, and roles). To access the cdc tables use the CDC user which has privileges
+to obtain the CDC data.
+
+```sql
+
+-- Example for On-Premise databases - Tailor the script to your needs
+-- ====  
+-- Enable Database for CDC template   
+-- ====  
+
+USE AdventureWorks2016 ;  
+
+EXEC sp_changedbowner 'sa';
+
+EXEC sys.sp_cdc_enable_db;  
+
+-- ====  
+-- Create a new File Group for the CDC tables   
+-- ====  
+
+USE AdventureWorks2016;
+
+ALTER DATABASE AdventureWorks2016 ADD FILEGROUP CDC_FILEGROUP;
+
+-- Add files to the filegroup
+
+ALTER DATABASE AdventureWorks2016 ADD FILE ( NAME = cdc_files, FILENAME = 'C:\MySQLFiles\CDC_FILES' ) to FILEGROUP CDC_FILEGROUP;
+
+-- ====  
+-- Enable Snapshot Isolation - Highly recommended for read consistency and to avoid dirty commits.   
+-- ====  
+
+-- https://www.sqlservercentral.com/articles/what-when-and-who-auditing-101-part-2
+-- Consider running one of these options to ensure read consistency. Do consider the impact however of enabling these features.
+
+ALTER DATABASE AdventureWorks2016
+SET READ_COMMITTED_SNAPSHOT ON;
+
+ALTER DATABASE AdventureWorks2016
+SET ALLOW_SNAPSHOT_ISOLATION ON;
+
+SELECT DB_NAME(database_id), 
+    is_read_committed_snapshot_on,
+    snapshot_isolation_state_desc
+FROM sys.databases
+WHERE database_id = DB_ID();
+
+-- ====  
+-- Create a new Role for accessing the CDC tables   
+-- ====
+
+USE AdventureWorks2016;
+
+-- Create a new login
+
+CREATE LOGIN CDC_USER WITH PASSWORD = '<cdc_user password>';
+
+ALTER SERVER ROLE sysadmin ADD MEMBER CDC_USER;
+
+-- Create a new user associated with the new login and access to the database
+
+CREATE USER CDC_USER FOR LOGIN CDC_USER;
+
+ALTER USER CDC_USER WITH DEFAULT_SCHEMA=dbo;
+
+-- ====  
+-- Create a new Role for accessing the CDC tables   
+-- ====
+
+CREATE ROLE CDC_Role;
+
+ALTER ROLE CDC_Role ADD MEMBER CDC_USER;
+
+-- Add explicit permissions to tracked tables, use this script to generate the required grant permissions
+
+-- ====  
+-- Add required CDC permissions to the CDC role   
+-- ====
+
+
+
+-- =========  
+-- Enable CDC Tracking on tables Specifying Filegroup Option Template  
+-- =========  
+USE AdventureWorks2016  
+;  
+  
+EXEC sys.sp_cdc_enable_table  
+@source_schema = N'HumanResources',
+@source_name   = N'Department',  
+@role_name     = N'CDC_Role',  
+@filegroup_name = N'CDC_FILEGROUP',  
+@supports_net_changes = 1  
+; 
+
+EXEC sys.sp_cdc_enable_table  
+@source_schema = N'HumanResources',
+@source_name   = N'Employee',  
+@role_name     = N'CDC_Role',  
+@filegroup_name = N'CDC_FILEGROUP',  
+@supports_net_changes = 1  
+; 
+
+EXEC sys.sp_cdc_enable_table  
+@source_schema = N'Person',
+@source_name   = N'Person',  
+@role_name     = N'CDC_Role',  
+@filegroup_name = N'CDC_FILEGROUP',  
+@supports_net_changes = 1  
+; 
+
+EXEC sys.sp_cdc_enable_table  
+@source_schema = N'Person',
+@source_name   = N'BusinessEntity',  
+@role_name     = N'CDC_Role',  
+@filegroup_name = N'CDC_FILEGROUP',  
+@supports_net_changes = 1  
+; 
+
+-- =========  
+-- Fixing the logging if it was not working  
+-- =========  
+
+-- Stopping the Capture Process
+
+-- Flushing the logs
+EXEC sp_repldone @xactid = NULL, @xact_segno = NULL, @numtrans = 0, @time = 0, @reset = 1; EXEC sp_replflush;
+
+-- Start the Capture Process
+
+-- =========  
+-- CDC Queries to check what is happening  
+-- =========  
+
+-- Check for CDC errors
+select *
+from sys.dm_cdc_errors;
+
+-- Stop the CDC Capture Job
+exec sys.sp_cdc_stop_job;
+
+-- Start the CDC Capture Job
+EXEC sys.sp_cdc_start_job;
+
+-- Check that CDC is enabled on the database
+SELECT name, is_cdc_enabled
+FROM sys.databases WHERE database_id = DB_ID();
+
+-- Check tables which have CDC enabled on them
+select s.name as schema_name, t.name as table_name, t.is_tracked_by_cdc, t.object_id
+from sys.tables t
+join sys.schemas s on (s.schema_id = t.schema_id)
+where t.is_tracked_by_cdc = 1
+;
+
+```
+
+
+```sql
+
+-- Example for Azure or AWS RDS databases - Tailor the example script to your needs
+
+/*
+
+Note:
+Snapshot Isolation level HASN'T been implemented as part of the the recommendation below as it can cause:
+https://www.sqlservercentral.com/articles/row-level-versioning
+-Increases resource usage when modifying data since row versions are maintained in tempDB.
+-Update and Delete transaction will use more resource since it has to create a snapshot in the tempDB. This could cause higher IO, CPU and Memory usage.
+-TempDB must have enough space to handle all the additional requirements.
+-14 Bytes will be added to the row in the database to keep track of the versions.
+-If there are long version chains then Data Read performance will be affected.
+
+*/
+
+
+-- ====  
+-- Enable Database for CDC template   
+-- ====  
+
+USE [<database_name>];  
+
+EXEC sp_changedbowner 'sa';
+--For AWS RDS dbowner is rdsa so no need to run the above statement.
+
+EXEC sys.sp_cdc_enable_db;  
+--Equivalent command to above on Azure or AWS RDS as per below:
+
+--AWS RDS:
+exec msdb.dbo.rds_cdc_enable_db [<database_name>]
+--Otherwise running above command: EXEC sys.sp_cdc_enable_db; on AWS RDS db will give you permission error: "Msg 22902, Level 16, State 1, Procedure sp_cdc_enable_db, Line 21 [Batch Start Line 9]
+--Caller is not authorized to initiate the requested action. Sysadmin privileges are required."
+
+--Azure: This is same as normal SQL command above.
+sys.sp_cdc_enable_db;
+
+--Query to check if cdc is enabled:
+SELECT name, is_cdc_enabled
+FROM sys.databases WHERE database_id = DB_ID();
+
+-- ====  
+-- Create a new File Group for the CDC tables   
+-- ====  
+
+USE [<database_name>];
+
+ALTER DATABASE [<database_name>] ADD FILEGROUP CDC_FILEGROUP;
+
+-- Add files to the filegroup
+
+ALTER DATABASE [<database_name>] ADD FILE ( NAME = cdc_files, FILENAME = 'C:\MySQLFiles\CDC_FILES' )to FILEGROUP CDC_FILEGROUP;
+
+-- ====  
+-- Enable Snapshot Isolation - Highly recommended for read consistency and to avoid dirty commits.   
+-- ====  
+
+/*
+-- https://www.sqlservercentral.com/articles/what-when-and-who-auditing-101-part-2
+-- Consider running one of these options to ensure read consistency. Do consider the impact however of enabling these features.
+
+ALTER DATABASE [<database_name>]
+SET READ_COMMITTED_SNAPSHOT ON;
+
+ALTER DATABASE [<database_name>]
+SET ALLOW_SNAPSHOT_ISOLATION ON;
+
+SELECT DB_NAME(database_id), 
+    is_read_committed_snapshot_on,
+    snapshot_isolation_state_desc
+FROM sys.databases
+WHERE database_id = DB_ID();
+
+Comments:
+Configuring snapshots can also affect performance and have added I/O and CPU overhead:
+With enabling Snapshots this would
+1.	Increase resource usage when modifying data since row versions are maintained in tempDB.
+2.	Update and Delete transaction will use more resource since it has to create a snapshot in the tempDB. This could cause higher IO, CPU and Memory usage.
+3.	TempDB must have enough space to handle all the additional requirements.
+4.	14 Bytes will be added to the row in the database to keep track of the versions.
+5.	If there are long version chains then Data Read performance will be affected.
+
+So I am suggesting/recommending that we leave snapshot isolation settings out of the mix and see if there are any concurrency issues during reads with cdc once that is implemented.
+
+
+*/
+
+
+-- ====  
+-- Create a new Role for accessing the CDC tables   
+-- ====
+
+USE [<database_name>];
+
+-- Create a new login
+
+CREATE LOGIN CDC_USER WITH PASSWORD = '<EnterPassword>',
+DEFAULT_DATABASE=[<database_name>], CHECK_EXPIRATION=OFF, CHECK_POLICY=ON;
+
+--ALTER SERVER ROLE sysadmin ADD MEMBER SA_SQLDProv_CDCUser;
+--Above is not required
+
+-- Create a new user associated with the new login and access to the database
+
+CREATE USER CDC_USER FOR LOGIN CDC_USER;
+
+ALTER USER CDC_USER WITH DEFAULT_SCHEMA=dbo;
+
+-- ====  
+-- Create a new Role for accessing the CDC tables   
+-- ====
+
+CREATE ROLE CDC_Role;
+
+
+ALTER ROLE CDC_Role ADD MEMBER CDC_USER;
+
+-- Add explicit permissions to tracked tables, use this script to generate the required grant permissions
+
+-- ====  
+-- Add required CDC permissions to the CDC role   
+-- ====
+USE [<database_name>]
+GO
+ALTER ROLE [db_owner] ADD MEMBER [CDC_Role]
+GO
+
+--OR
+----
+
+USE [<database_name>]
+GO
+ALTER ROLE [db_datareader] ADD MEMBER [CDC_Role]
+GO
+
+
+USE [<database_name>]
+GO
+
+GRANT EXECUTE ON SCHEMA ::cdc TO [CDC_Role]
+GO
+
+GRANT VIEW DATABASE STATE TO [CDC_Role]
+GO
+
+-- =========  
+-- Enable CDC Tracking on tables Specifying Filegroup Option Template  
+-- =========  
+  
+  
+--https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sys-sp-cdc-enable-table-transact-sql?view=sql-server-ver15 (for @supports_net_changes description)
+--If 1, the functions that are needed to query for net changes are also generated.If supports_net_changes is set to 1, index_name must be specified, or the source table must have a defined primary key.
+--Most tables have a primary key so index_name can be ommited. 
+/*
+Table list to enable CDC:
+1.	TABLE1
+2.	TABLE2
+3.	....
+
+IMPORTANT: Please ensure that the user to access the CDC tables e.g. CDC_USER has access to the appropriate CDC Role e.g. CDC_Role. The role specified in the sys.sp_cdc_enable_table
+           function must align with the CDC role allocated to the CDC_User.
+
+*/
+
+
+
+USE [<database_name>];
+
+--1.	EXAM
+=============
+EXEC sys.sp_cdc_enable_table  
+@source_schema = N'dbo',
+@source_name   = N'TABLE1',  
+@role_name     = N'CDC_Role',  
+@filegroup_name = N'CDC_FILEGROUP',  
+@supports_net_changes = 1; 
+
+--2.	EXAM_CODES
+=============
+EXEC sys.sp_cdc_enable_table  
+@source_schema = N'dbo',
+@source_name   = N'TABLE2',  
+@role_name     = N'CDC_Role',  
+@filegroup_name = N'CDC_FILEGROUP',  
+@supports_net_changes = 1; 
+
+
+-- =========  
+-- Fixing the logging if it was not working  
+-- =========  
+
+-- Stopping the Capture Process
+
+-- Flushing the logs
+EXEC sp_repldone @xactid = NULL, @xact_segno = NULL, @numtrans = 0, @time = 0, @reset = 1; EXEC sp_replflush;
+
+-- Start the Capture Process
+
+-- =========  
+-- CDC Queries to check what is happening  
+-- =========  
+
+-- Check for CDC errors
+select *
+from sys.dm_cdc_errors;
+
+--To get cdc job information:
+select * from msdb.dbo.sysjobs
+--Or Use database that has cdc enabled:
+Use <database_name>
+Exec sys.sp_cdc_help_jobs  
+
+-- Stop the CDC Capture Job
+exec sys.sp_cdc_stop_job;
+
+-- Start the CDC Capture Job
+EXEC sys.sp_cdc_start_job;
+
+-- Check that CDC is enabled on the database
+SELECT name, is_cdc_enabled
+FROM sys.databases WHERE database_id = DB_ID();
+
+-- Check tables which have CDC enabled on them
+select s.name as schema_name, t.name as table_name, t.is_tracked_by_cdc, t.object_id
+from sys.tables t
+join sys.schemas s on (s.schema_id = t.schema_id)
+where t.is_tracked_by_cdc = 1
+;
+
+--Get cdc details:
+Use <database_name>;
+Exec sys.sp_cdc_help_change_data_capture;
+
+--CDC System tables located under <database_name> > System Tables
+
+
+--BACKOUT PLAN
+--============================================
+--To disable cdc on indvidual tables:
+--The Change Data Capture can easily be disabled on a given table with the help of the sys.sp_cdc_disable_table system stored procedure, as stated below:
+EXEC sys.sp_cdc_disable_table  
+@source_schema = N'dbo',
+@source_name   = N'<Table_Name>',  
+@role_name     = N'CDC_Role',  
+@capture_instace =N'<Capture_instance>'; 
+--Capture instance name can be found using the following query: Normally Capture_instance name is just Schema_TableName eg: dbo_Patient
+Select * from cdc.change_tables
+
+EXEC sys.sp_cdc_disable_table 
+@source_schema = N'dbo',
+@source_name   = N'TABLE1',
+@capture_instance =N'dbo_TABLE1';
+
+EXEC sys.sp_cdc_disable_table  
+@source_schema = N'dbo',
+@source_name   = N'TABLE2',  
+@capture_instance =N'dbo_TABLE2'; 
+
+--To disable cdc on DB:
+--You can disable SQL Server CDC completely at the database level, without the need to disable it on CDC-enabled tables one at a time. 
+exec msdb.dbo.rds_cdc_disable_db [<database_name>];
+
+--Remove Logins, db_users, roles created above.
+
+--Romove FILEGROUP 'CDC_FILEGROUP'
+
+```

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ To emit a date as a date without a time component. This is helpful to avoid time
 {
   "use_date_datatype": true
 }
+```
 
 These are the same basic configuration properties used by the mssql command-line
 client (`mssql`).

--- a/README.md
+++ b/README.md
@@ -105,12 +105,22 @@ To emit a date as a date without a time component or time without an UTC offset.
 
 Optional:
 
-Set the version of TDS to use when communicating with MS SQL Server. This is used by pymssql with connecting and fetching data from SQL Server databases. See the [pymssql](https://pymssql.readthedocs.io/en/stable/index.html) documentation and [FreeTDS](https://www.freetds.org/) documentation for more details.
+Set the version of TDS to use when communicating with MS SQL Server (the default is 7.3). This is used by pymssql with connecting and fetching data from SQL Server databases. See the [pymssql](https://pymssql.readthedocs.io/en/stable/index.html) documentation and [FreeTDS](https://www.freetds.org/) documentation for more details.
 ```json
 {
   "tds_version": "7.3"
 }
 ```
+
+Optional:
+
+The characterset for the database / source system. The default is `utf8`, however older databases might use a charactersets like [cp1252](https://en.wikipedia.org/wiki/Windows-1252) for the encoding. If you have errors with a `UnicodeDecodeError: 'utf-8' codec can't decode byte ....` then a solution is examine the characterset of the source database / system and make an appropriate substitution for utf8 like cp1252. 
+```json
+{
+  "characterset": "utf8"
+}
+```
+
 These are the same basic configuration properties used by the mssql command-line
 client (`mssql`).
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To filter the discovery to a particular schema within a database. This is useful
 
 Optional:
 
-To emit a date as a date without a time component or time without an UTC offset. This is helpful to avoid time conversions or to just work with a date datetype in the target database. If this config item is not set, the default behaviour is `false` i.e. emit date datatypes as a datetime.
+To emit a date as a date without a time component or time without an UTC offset. This is helpful to avoid time conversions or to just work with a date datetype in the target database. If this boolean config item is not set, the default behaviour is `false` i.e. emit date datatypes as a datetime. It is recommended to set this on if you have time datetypes and are having issues uploading into into a target database.
 ```json
 {
   "use_date_datatype": true

--- a/README.md
+++ b/README.md
@@ -308,13 +308,28 @@ resultant stream of JSON data can be consumed by a Singer target.
 ## Replication methods and state file
 
 In the above example, we invoked `tap-mssql` without providing a _state_ file
-and without specifying a replication method. The two ways to replicate a given
-table are `FULL_TABLE` and `INCREMENTAL`.
+and without specifying a replication method. The three ways to replicate a given
+table are `FULL_TABLE`, `LOG_BASED`, and `INCREMENTAL`.
 
 ### Full Table
 
 Full-table replication extracts all data from the source table each time the tap
 is invoked.
+
+### Log Based
+
+Log_Based replication extracts change data from the MS SQL Server Change Data Capture (CDC) tables you have enrolled.
+
+This method allows you to replicate just the changes to a table e.g. the Inserts, Deletes, and Updates. For this method to work you
+must enrol the database in question and tables that you wish to replicate.
+
+See : https://docs.microsoft.com/en-us/sql/relational-databases/track-changes/enable-and-disable-change-data-capture-sql-server for
+more details.
+
+Please Note: CDC is different to Change Tracking which is a older approach for tracking change. Log Based only works with CDC, it does
+not work with Change Tracking!
+
+To find out more about setting up CDC, refer to this page [MSSQL CDC Setup](MS_CDC_SETUP.md)
 
 ### Incremental
 
@@ -442,3 +457,64 @@ This invocation extracts any data since (and including) the
 ---
 
 Based on Stitch documentation
+
+
+## Build Instructions
+
+This section dives into basic commands to build `tap-mssql` if an alteration is made to the code.
+
+### Setup Tools
+
+You may need a copy of setup tools or an up to date version of setup tools to build `tap-mssql`
+
+To do this follow these instructions.
+
+```bash
+  # Ensure you have first sourced the python virtual environment e.g.
+  source venv/bin/activate
+
+  python -m pip install --upgrade setuptools
+```
+
+### To build the tap
+
+Run the following command each time you need to rebuild the tap.
+
+```bash
+$ python setup.py install
+```
+
+### Debugging in Visual Studio Code
+
+To run the __init__.py python program in debug mode, you need to do the following two steps. Note: This was run within a Docker Container in Visual Studio Code.
+
+1. Create a .vscode/launch.json file. Note: The parameters config.json and properties.json should point to the files you have generated in previous steps above.
+   If you want to test state, include the state parameter as shown below and prepare an appropriate state file as per the instructions in an earlier section.
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Program",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceRoot}/tap_mssql/__init__.py",
+            "args": [
+                "-c", "config.json",
+                "--properties", "properties.json"
+                "--state", "state.json"
+            ]
+        }
+    ]
+}
+```
+2. Add a main entry to the __init__.py file to run interactively
+
+Add the following lines to the end of the __init__.py in the tap_mssql directory.
+
+```python
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter
+```

--- a/README.md
+++ b/README.md
@@ -96,13 +96,21 @@ To filter the discovery to a particular schema within a database. This is useful
 
 Optional:
 
-To emit a date as a date without a time component. This is helpful to avoid time conversions or to just work with a date datetype in the target database. If this config item is not set, the default behaviour is `false` i.e. emit date datatypes as a datetime.
+To emit a date as a date without a time component or time without an UTC offset. This is helpful to avoid time conversions or to just work with a date datetype in the target database. If this config item is not set, the default behaviour is `false` i.e. emit date datatypes as a datetime.
 ```json
 {
   "use_date_datatype": true
 }
 ```
 
+Optional:
+
+Set the version of TDS to use when communicating with MS SQL Server. This is used by pymssql with connecting and fetching data from SQL Server databases. See the [pymssql](https://pymssql.readthedocs.io/en/stable/index.html) documentation and [FreeTDS](https://www.freetds.org/) documentation for more details.
+```json
+{
+  "tds_version": "7.3"
+}
+```
 These are the same basic configuration properties used by the mssql command-line
 client (`mssql`).
 

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -25,6 +25,7 @@ from singer.catalog import Catalog, CatalogEntry
 import tap_mssql.sync_strategies.common as common
 import tap_mssql.sync_strategies.full_table as full_table
 import tap_mssql.sync_strategies.incremental as incremental
+import tap_mssql.sync_strategies.log_based as log_based
 
 from tap_mssql.connection import connect_with_backoff, MSSQLConnection
 
@@ -326,6 +327,35 @@ def desired_columns(selected, table_schema):
 
 
 def is_valid_currently_syncing_stream(selected_stream, state):
+    stream_metadata = metadata.to_map(selected_stream.metadata)
+    replication_method = stream_metadata.get((), {}).get('replication-method')
+
+    if replication_method != 'LOG_BASED':
+        return True
+
+    if replication_method == 'LOG_BASED' and cdc_stream_requires_historical(selected_stream, state):
+        return True
+
+    return False
+
+
+def cdc_stream_requires_historical(catalog_entry, state):
+
+    current_lsn = singer.get_bookmark(state,
+                                  catalog_entry.tap_stream_id,
+                                  'lsn')
+
+    max_lsn_values = singer.get_bookmark(state,
+                                        catalog_entry.tap_stream_id,
+                                        'max_lsn_values')
+
+    last_lsn_fetched = singer.get_bookmark(state,
+                                          catalog_entry.tap_stream_id,
+                                          'last_lsn_fetched')
+
+    if (current_lsn) and (not max_lsn_values and not last_lsn_fetched):
+        return False
+
     return True
 
 
@@ -373,7 +403,7 @@ def resolve_catalog(discovered_catalog, streams_to_sync):
     return result
 
 
-def get_non_binlog_streams(mssql_conn, catalog, config, state):
+def get_non_cdc_streams(mssql_conn, catalog, config, state):
     """Returns the Catalog of data we're going to sync for all SELECT-based
     streams (i.e. INCREMENTAL, FULL_TABLE, and LOG_BASED that require a historical
     sync). LOG_BASED streams that require a historical sync are inferred from lack
@@ -411,8 +441,20 @@ def get_non_binlog_streams(mssql_conn, catalog, config, state):
         stream_state = state.get("bookmarks", {}).get(stream.tap_stream_id)
 
         if not stream_state:
+            if replication_method == 'LOG_BASED':
+                LOGGER.info("LOG_BASED stream %s requires full historical sync", stream.tap_stream_id)
+
             streams_without_state.append(stream)
-        else:
+        elif stream_state and replication_method == 'LOG_BASED' and cdc_stream_requires_historical(stream, state):
+            is_view = common.get_is_view(stream)
+
+            if is_view:
+                raise Exception("Unable to replicate stream({}) with cdc because it is a view.".format(stream.stream))
+
+            LOGGER.info("LOG_BASED stream %s will resume its historical sync", stream.tap_stream_id)
+
+            streams_with_state.append(stream)
+        elif stream_state and replication_method != 'LOG_BASED':
             streams_with_state.append(stream)
 
     # If the state says we were in the middle of processing a stream, skip
@@ -441,18 +483,21 @@ def get_non_binlog_streams(mssql_conn, catalog, config, state):
     return resolve_catalog(discovered, streams_to_sync)
 
 
-def get_binlog_streams(mssql_conn, catalog, config, state):
+def get_cdc_streams(mssql_conn, catalog, config, state):
     discovered = discover_catalog(mssql_conn, config)
 
     selected_streams = list(filter(lambda s: common.stream_is_selected(s), catalog.streams))
-    binlog_streams = []
+    cdc_streams = []
 
     for stream in selected_streams:
         stream_metadata = metadata.to_map(stream.metadata)
         replication_method = stream_metadata.get((), {}).get("replication-method")
         stream_state = state.get("bookmarks", {}).get(stream.tap_stream_id)
 
-    return resolve_catalog(discovered, binlog_streams)
+        if replication_method == 'LOG_BASED' and not cdc_stream_requires_historical(stream, state):
+            cdc_streams.append(stream)
+
+    return resolve_catalog(discovered, cdc_streams)
 
 
 def write_schema_message(catalog_entry, bookmark_properties=[]):
@@ -480,6 +525,30 @@ def do_sync_incremental(mssql_conn, config, catalog_entry, state, columns):
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
 
+def do_sync_historical_log(mssql_conn, config, catalog_entry, state, columns):
+    key_properties = common.get_key_properties(catalog_entry)
+    mssql_conn = MSSQLConnection(config)
+
+    # Add additional keys to the schema
+    log_based.add_synthetic_keys_to_schema(catalog_entry)
+
+    write_schema_message(catalog_entry)
+
+    stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
+
+    # full_table.sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version)
+    log_based.sync_historic_table(mssql_conn, config, catalog_entry, state, columns, stream_version)    
+
+    # Prefer initial_full_table_complete going forward
+    singer.clear_bookmark(state, catalog_entry.tap_stream_id, "version")
+
+    state = singer.write_bookmark(
+        state, catalog_entry.tap_stream_id, "initial_full_table_complete", True
+    )
+
+    singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+
+
 def do_sync_full_table(mssql_conn, config, catalog_entry, state, columns):
     key_properties = common.get_key_properties(catalog_entry)
     mssql_conn = MSSQLConnection(config)
@@ -497,11 +566,26 @@ def do_sync_full_table(mssql_conn, config, catalog_entry, state, columns):
 
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
+def do_sync_log_based(mssql_conn, config, catalog_entry, state, columns):
+    mssql_conn = MSSQLConnection(config)
+    md_map = metadata.to_map(catalog_entry.metadata)
+    stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
+    replication_key = md_map.get((), {}).get("replication-key")
+    # Add additional keys to the schema
+    log_based.add_synthetic_keys_to_schema(catalog_entry)
 
-def sync_non_binlog_streams(mssql_conn, non_binlog_catalog, config, state):
+    write_schema_message(catalog_entry=catalog_entry, bookmark_properties=[replication_key])
+    LOGGER.info("Schema written")
+    stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
+    log_based.sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version)
+
+    singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+
+
+def sync_non_cdc_streams(mssql_conn, non_cdc_catalog, config, state):
     mssql_conn = MSSQLConnection(config)
 
-    for catalog_entry in non_binlog_catalog.streams:
+    for catalog_entry in non_cdc_catalog.streams:
         columns = list(catalog_entry.schema.properties.keys())
 
         if not columns:
@@ -517,9 +601,10 @@ def sync_non_binlog_streams(mssql_conn, non_binlog_catalog, config, state):
         replication_method = md_map.get((), {}).get("replication-method")
         replication_key = md_map.get((), {}).get("replication-key")
         primary_keys = common.get_key_properties(catalog_entry)
+        start_lsn = md_map.get((), {}).get("lsn")
         LOGGER.info(f"Table {catalog_entry.table} proposes {replication_method} sync")
         if not replication_method and config.get("default_replication_method"):
-            replication_method= config.get("default_replication_method") 
+            replication_method= config.get("default_replication_method")
             LOGGER.info(f"Table {catalog_entry.table} reverting to DEFAULT {replication_method} sync")
 
         if replication_method == "INCREMENTAL" and not replication_key:
@@ -528,7 +613,12 @@ def sync_non_binlog_streams(mssql_conn, non_binlog_catalog, config, state):
         if replication_method == "INCREMENTAL" and not primary_keys:
             LOGGER.info(f"No primary key for {catalog_entry.table}, using full table replication")
             replication_method = "FULL_TABLE"
-        LOGGER.info(f"Table {catalog_entry.table} will use {replication_method} sync")
+        if replication_method == "LOG_BASED" and not start_lsn:
+            LOGGER.info(
+                f"No initial load for {catalog_entry.table}, using full table replication"
+            )
+        else:        
+            LOGGER.info(f"Table {catalog_entry.table} will use {replication_method} sync")
 
         database_name = common.get_database_name(catalog_entry)
 
@@ -542,19 +632,65 @@ def sync_non_binlog_streams(mssql_conn, non_binlog_catalog, config, state):
             elif replication_method == "FULL_TABLE":
                 LOGGER.info(f"syncing {catalog_entry.table} full table")
                 do_sync_full_table(mssql_conn, config, catalog_entry, state, columns)
+            elif replication_method == "LOG_BASED":
+                LOGGER.info(f"syncing {catalog_entry.table} cdc tables")
+                do_sync_historical_log(mssql_conn, config, catalog_entry, state, columns)               
             else:
-                raise Exception("only INCREMENTAL and FULL TABLE replication methods are supported")
+                raise Exception("only INCREMENTAL, LOG_BASED and FULL TABLE replication methods are supported")
 
     state = singer.set_currently_syncing(state, None)
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
 
+def sync_cdc_streams(mssql_conn, cdc_catalog, config, state):
+    mssql_conn = MSSQLConnection(config)
+
+    if cdc_catalog.streams:
+        for catalog_entry in cdc_catalog.streams:
+            columns = list(catalog_entry.schema.properties.keys())
+            if not columns:
+                LOGGER.warning(
+                    "There are no columns selected for stream %s, skipping it.", catalog_entry.stream
+                )
+                continue
+
+            state = singer.set_currently_syncing(state, catalog_entry.tap_stream_id)
+
+            # Emit a state message to indicate that we've started this stream
+            singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+
+            md_map = metadata.to_map(catalog_entry.metadata)
+            replication_method = md_map.get((), {}).get("replication-method")
+            replication_key = md_map.get((), {}).get("replication-key")
+            primary_keys = md_map.get((), {}).get("table-key-properties")
+            LOGGER.info(f"Table {catalog_entry.table} proposes {replication_method} sync")
+            LOGGER.info(f"Table {catalog_entry.table} will use {replication_method} sync")
+
+            database_name = common.get_database_name(catalog_entry)
+
+            with metrics.job_timer('table_cdc_sync') as timer:
+                timer.tags["database"] = database_name
+                timer.tags["table"] = catalog_entry.table
+
+                if replication_method == "LOG_BASED":
+                    LOGGER.info(f"syncing {catalog_entry.table} cdc tables")
+                    do_sync_log_based(mssql_conn, config, catalog_entry, state, columns)                
+                else:
+                    raise Exception("only LOG_BASED methods are supported for CDC")
+
+        state = singer.set_currently_syncing(state, None)
+        singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))                    
+
+
 def do_sync(mssql_conn, config, catalog, state):
     LOGGER.info("Beginning sync")
-    non_binlog_catalog = get_non_binlog_streams(mssql_conn, catalog, config, state)
-    for entry in non_binlog_catalog.streams:
+    non_cdc_catalog = get_non_cdc_streams(mssql_conn, catalog, config, state)
+    cdc_catalog = get_cdc_streams(mssql_conn, catalog, config, state)
+
+    for entry in non_cdc_catalog.streams:
         LOGGER.info(f"Need to sync {entry.table}")
-    sync_non_binlog_streams(mssql_conn, non_binlog_catalog, config, state)
+    sync_non_cdc_streams(mssql_conn, non_cdc_catalog, config, state)
+    sync_cdc_streams(mssql_conn, cdc_catalog, config, state)
 
 
 def log_server_params(mssql_conn):

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -84,12 +84,16 @@ TIME_TYPES = set(["time"])
 
 VARIANT_TYPES = set(["json"])
 
+def default_date_format():
+    return False
 
-def schema_for_column(c):
+def schema_for_column(c, config):
     """Returns the Schema object for the given Column."""
     data_type = c.data_type.lower()
 
     inclusion = "available"
+
+    use_date_data_type_format = config.get("use_date_datatype") or default_date_format()
 
     if c.is_primary_key == 1:
         inclusion = "automatic"
@@ -125,12 +129,20 @@ def schema_for_column(c):
         result.format = "date-time"
 
     elif data_type in DATE_TYPES:
-        result.type = ["null", "string"]
-        result.format = "date"
+        if use_date_data_type_format:
+            result.type = ["null", "string"]
+            result.format = "date"
+        else:
+            result.type = ["null", "string"]
+            result.format = "date-time"
 
     elif data_type in TIME_TYPES:
-        result.type = ["null", "string"]
-        result.format = "time"
+        if use_date_data_type_format:
+            result.type = ["null", "string"]
+            result.format = "time"
+        else:
+            result.type = ["null", "string"]
+            result.format = "date-time"
 
     elif data_type in VARIANT_TYPES:
         result.type = ["null", "object"]
@@ -144,11 +156,11 @@ def schema_for_column(c):
     return result
 
 
-def create_column_metadata(cols):
+def create_column_metadata(cols, config):
     mdata = {}
     mdata = metadata.write(mdata, (), "selected-by-default", False)
     for c in cols:
-        schema = schema_for_column(c)
+        schema = schema_for_column(c, config)
         mdata = metadata.write(
             mdata,
             ("properties", c.column_name),
@@ -243,8 +255,8 @@ def discover_catalog(mssql_conn, config):
         for (k, cols) in itertools.groupby(columns, lambda c: (c.table_schema, c.table_name)):
             cols = list(cols)
             (table_schema, table_name) = k
-            schema = Schema(type="object", properties={c.column_name: schema_for_column(c) for c in cols})
-            md = create_column_metadata(cols)
+            schema = Schema(type="object", properties={c.column_name: schema_for_column(c, config) for c in cols})
+            md = create_column_metadata(cols, config)
             md_map = metadata.to_map(md)
 
             md_map = metadata.write(md_map, (), "database-name", table_schema)

--- a/tap_mssql/connection.py
+++ b/tap_mssql/connection.py
@@ -34,7 +34,7 @@ class MSSQLConnection(pymssql.Connection):
             "password": config.get("password"),
             "server": config["host"],
             "database": config["database"],
-            "charset": "utf8",
+            "charset": config.get("characterset", "utf8"),
             "port": config.get("port", "1433"),
             "tds_version": config.get("tds_version", "7.3"),
         }

--- a/tap_mssql/connection.py
+++ b/tap_mssql/connection.py
@@ -36,7 +36,7 @@ class MSSQLConnection(pymssql.Connection):
             "database": config["database"],
             "charset": "utf8",
             "port": config.get("port", "1433"),
-            "tds_version": config.get("tds_version", "8.0"),
+            "tds_version": config.get("tds_version", "7.3"),
         }
         conn = pymssql._mssql.connect(**args)
         super().__init__(conn, False, True)

--- a/tap_mssql/sync_strategies/common.py
+++ b/tap_mssql/sync_strategies/common.py
@@ -101,7 +101,11 @@ def row_to_singer_record(catalog_entry, version, row, columns, time_extracted, c
             row_to_persist += (elem.isoformat() + "+00:00",)
 
         elif isinstance(elem, datetime.time):
-            row_to_persist += (elem.isoformat() + "+00:00",)
+            if use_date_data_type_format:
+                # Writing Dates with a Date Datatype, not converting it to a datetime.
+                row_to_persist += (elem.isoformat(),)
+            else:
+                row_to_persist += (elem.isoformat() + "+00:00",)
 
         elif isinstance(elem, datetime.date):
             if use_date_data_type_format:

--- a/tap_mssql/sync_strategies/common.py
+++ b/tap_mssql/sync_strategies/common.py
@@ -182,7 +182,7 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
             stream_metadata = md_map.get((), {})
             replication_method = stream_metadata.get("replication-method")
 
-            if replication_method in {"FULL_TABLE", "LOG_BASED"}:
+            if replication_method == "FULL_TABLE":
                 key_properties = get_key_properties(catalog_entry)
 
                 max_pk_values = singer.get_bookmark(
@@ -196,6 +196,22 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
 
                     state = singer.write_bookmark(
                         state, catalog_entry.tap_stream_id, "last_pk_fetched", last_pk_fetched
+                    )
+
+            elif replication_method == "LOG_BASED":
+                key_properties = get_key_properties(catalog_entry)
+
+                max_lsn_values = singer.get_bookmark(
+                    state, catalog_entry.tap_stream_id, "max_lsn_values"
+                )
+
+                if max_lsn_values:
+                    last_lsn_fetched = {
+                        k: v for k, v in record_message.record.items() if k in key_properties
+                    }
+
+                    state = singer.write_bookmark(
+                        state, catalog_entry.tap_stream_id, "last_lsn_fetched", last_lsn_fetched
                     )
 
             elif replication_method == "INCREMENTAL":

--- a/tap_mssql/sync_strategies/log_based.py
+++ b/tap_mssql/sync_strategies/log_based.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# pylint: disable=duplicate-code,too-many-locals,simplifiable-if-expression
+
+import copy
+import singer
+from singer import metadata
+from singer.schema import Schema
+
+import tap_mssql.sync_strategies.common as common
+
+from tap_mssql.connection import connect_with_backoff, MSSQLConnection
+
+LOGGER = singer.get_logger()
+
+def py_bin_to_mssql(binary_value):
+    return "CONVERT(BINARY(10),'0x" + binary_value + "',1)"
+
+def verify_change_data_capture_table(connection, schema_name, table_name):
+    cur = connection.cursor()
+    cur.execute("""select s.name as schema_name, t.name as table_name, t.is_tracked_by_cdc, t.object_id
+                   from sys.tables t
+                   join sys.schemas s on (s.schema_id = t.schema_id)
+                   and  t.name = '{}'
+                   and  s.name = '{}'""".format(table_name,schema_name)
+               )
+    row = cur.fetchone()
+        
+    return row[2]
+
+def verify_change_data_capture_databases(connection):
+    cur = connection.cursor()
+    cur.execute("""SELECT name, is_cdc_enabled
+                   FROM sys.databases WHERE database_id = DB_ID()"""
+               )
+    row = cur.fetchone()
+
+    LOGGER.info(
+        "CDC Databases enable : Database %s, Enabled %s", *row,
+    )
+    return row
+
+def verify_read_isolation_databases(connection):
+    cur = connection.cursor()
+    cur.execute("""SELECT DB_NAME(database_id),
+                          is_read_committed_snapshot_on,
+                          snapshot_isolation_state_desc
+                   FROM sys.databases
+                   WHERE database_id = DB_ID();"""
+               )
+    row = cur.fetchone()
+
+    if row[1] == False and row[2] == "OFF":
+        LOGGER.warning(
+            "CDC Databases may result in dirty reads. Consider enabling Read Committed or Snapshot isolation: Database %s, Is Read Committed Snapshot is %s, Snapshot Isolation is %s", *row,
+        )
+    return row    
+
+def get_lsn_available_range(connection, capture_instance_name ):
+    cur = connection.cursor()
+    query = """SELECT sys.fn_cdc_get_min_lsn ( '{}' ) lsn_from
+                    , sys.fn_cdc_get_max_lsn () lsn_to
+               ;
+            """.format(capture_instance_name)
+    cur.execute(query)
+    row = cur.fetchone()
+
+    if row[0] is None:   # Test that the lsn_from is not NULL i.e. there is change data to process
+       LOGGER.info("No data available to process in CDC table %s", capture_instance_name)
+    else:
+       LOGGER.info("Data available in cdc table %s from lsn %s", capture_instance_name, row[0].hex())
+
+    return row
+
+def get_to_lsn(connection):
+    cur = connection.cursor()
+    query = """select sys.fn_cdc_get_max_lsn () """
+
+    cur.execute(query)
+    row = cur.fetchone()
+
+    LOGGER.info(
+        "Max LSN ID : %s", row[0].hex(),
+    )
+    return row 
+
+def add_synthetic_keys_to_schema(catalog_entry):
+   catalog_entry.schema.properties['_sdc_operation_type'] = Schema(
+            description='Source operation I=Insert, D=Delete, U=Update', type=['null', 'string'], format='string')  
+   catalog_entry.schema.properties['_sdc_lsn_commit_timestamp'] = Schema(
+            description='Source system commit timestamp', type=['null', 'string'], format='date-time')
+   catalog_entry.schema.properties['_sdc_lsn_deleted_at'] = Schema(
+            description='Source system delete timestamp', type=['null', 'string'], format='date-time')
+   catalog_entry.schema.properties['_sdc_lsn_value'] = Schema(
+            description='Source system log sequence number (LSN)', type=['null', 'string'], format='string')
+   catalog_entry.schema.properties['_sdc_lsn_seq_value'] = Schema(
+            description='Source sequence number within the system log sequence number (LSN)', type=['null', 'string'], format='string')                          
+   catalog_entry.schema.properties['_sdc_lsn_operation'] = Schema(
+            description='The operation that took place (1=Delete, 2=Insert, 3=Update (Before Image), 4=Update (After Image) )', type=['null', 'integer'], format='integer')  
+
+   return catalog_entry          
+
+def generate_bookmark_keys(catalog_entry):
+    md_map = metadata.to_map(catalog_entry.metadata)
+    stream_metadata = md_map.get((), {})
+    replication_method = stream_metadata.get("replication-method")
+
+    ### TO_DO: 
+    ### 1. check the use of the top three values above and the parameter value, seem to not be required.
+    ### 2. check the base_bookmark_keys required
+    base_bookmark_keys = {
+        "last_lsn_fetched",
+        "max_lsn_values",
+        "lsn",
+        "version",
+        "initial_full_table_complete",
+    }
+
+    bookmark_keys = base_bookmark_keys
+
+    return bookmark_keys
+
+def sync_historic_table(mssql_conn, config, catalog_entry, state, columns, stream_version):
+    mssql_conn = MSSQLConnection(config)
+    common.whitelist_bookmark_keys(
+        generate_bookmark_keys(catalog_entry), catalog_entry.tap_stream_id, state
+    )
+
+    # Add additional keys to the columns
+    extended_columns = columns + ['_sdc_operation_type', '_sdc_lsn_commit_timestamp', '_sdc_lsn_deleted_at', '_sdc_lsn_value', '_sdc_lsn_seq_value', '_sdc_lsn_operation']    
+
+    bookmark = state.get("bookmarks", {}).get(catalog_entry.tap_stream_id, {})
+    version_exists = True if "version" in bookmark else False
+
+    initial_full_table_complete = singer.get_bookmark(
+        state, catalog_entry.tap_stream_id, "initial_full_table_complete"
+    )
+
+    state_version = singer.get_bookmark(state, catalog_entry.tap_stream_id, "version")
+
+    activate_version_message = singer.ActivateVersionMessage(
+        stream=catalog_entry.stream, version=stream_version
+    )
+
+    # For the initial replication, emit an ACTIVATE_VERSION message
+    # at the beginning so the records show up right away.
+    if not initial_full_table_complete and not (version_exists and state_version is None):
+        singer.write_message(activate_version_message)
+
+    with connect_with_backoff(mssql_conn) as open_conn:
+        with open_conn.cursor() as cur:
+
+            escaped_columns = [common.escape(c) for c in columns]
+            table_name      = catalog_entry.table
+            schema_name     = common.get_database_name(catalog_entry)
+
+            if not verify_change_data_capture_table(mssql_conn,schema_name,table_name):
+               raise Exception("Error {}.{}: does not have change data capture enabled. Call EXEC sys.sp_cdc_enable_table with relevant parameters to enable CDC.".format(schema_name,table_name))            
+
+            verify_read_isolation_databases(mssql_conn)
+
+            # Store the current database lsn number, will use this to store at the end of the initial load.
+            # Note: Recommend no transactions loaded when the initial loads are performed.
+            lsn_to = str(get_to_lsn(mssql_conn)[0].hex())
+
+            select_sql = """
+                            SELECT {}
+                                ,'I' _sdc_operation_type
+                                , cast('1900-01-01' as datetime) _sdc_lsn_commit_timestamp
+                                , null _sdc_lsn_deleted_at
+                                , '00000000000000000000' _sdc_lsn_value
+                                , '00000000000000000000' _sdc_lsn_seq_value
+                                , 1 as _sdc_lsn_operation
+                            FROM {}.{}
+                            ;""".format(",".join(escaped_columns), schema_name, table_name)          
+            params = {}
+
+            common.sync_query(
+                cur, catalog_entry, state, select_sql, extended_columns, stream_version, params, config
+            )
+            state = singer.write_bookmark(state, catalog_entry.tap_stream_id, 'lsn', lsn_to)
+
+    # store the state of the table lsn's after the initial load ready for the next CDC run
+    singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+
+    # clear max pk value and last pk fetched upon successful sync
+    singer.clear_bookmark(state, catalog_entry.tap_stream_id, "max_pk_values")
+    singer.clear_bookmark(state, catalog_entry.tap_stream_id, "last_pk_fetched")
+
+    singer.write_message(activate_version_message)
+
+def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version):
+    mssql_conn = MSSQLConnection(config)
+    common.whitelist_bookmark_keys(
+        generate_bookmark_keys(catalog_entry), catalog_entry.tap_stream_id, state
+    )
+
+    # Add additional keys to the columns
+    extended_columns = columns + ['_sdc_operation_type', '_sdc_lsn_commit_timestamp', '_sdc_lsn_deleted_at', '_sdc_lsn_value', '_sdc_lsn_seq_value', '_sdc_lsn_operation']
+
+    bookmark = state.get("bookmarks", {}).get(catalog_entry.tap_stream_id, {})
+    version_exists = True if "version" in bookmark else False
+
+    initial_full_table_complete = singer.get_bookmark(
+        state, catalog_entry.tap_stream_id, "initial_full_table_complete"
+    )
+
+    state_version = singer.get_bookmark(state, catalog_entry.tap_stream_id, "version")
+
+    activate_version_message = singer.ActivateVersionMessage(
+        stream=catalog_entry.stream, version=stream_version
+    )
+
+    # For the initial replication, emit an ACTIVATE_VERSION message
+    # at the beginning so the records show up right away.
+    if not initial_full_table_complete and not (version_exists and state_version is None):
+        singer.write_message(activate_version_message)
+
+    with connect_with_backoff(mssql_conn) as open_conn:
+        with open_conn.cursor() as cur:
+
+            # start_lsn = min([singer.get_bookmark(state, s.tap_stream_id, 'lsn') for s in catalog_entry.stream])
+            state_last_lsn = singer.get_bookmark(state, catalog_entry.tap_stream_id, "lsn")
+            
+            escaped_columns = [common.escape(c) for c in columns]
+            table_name      = catalog_entry.table
+            schema_name     = common.get_database_name(catalog_entry)
+            schema_table   = schema_name + "_" + table_name
+
+            if not verify_change_data_capture_table(mssql_conn,schema_name,table_name):
+               raise Exception("Error {}.{}: does not have change data capture enabled. Call EXEC sys.sp_cdc_enable_table with relevant parameters to enable CDC.".format(schema_name,table_name))
+
+            # lsn_range = get_lsn_extract_range(mssql_conn, schema_name, table_name,"2016-08-01T23:00:00")
+            lsn_range = get_lsn_available_range(mssql_conn,schema_table)
+
+            if lsn_range[0] is not None:   # Test to see if there are any change records to process
+               lsn_from = str(lsn_range[0].hex())
+               lsn_to   = str(lsn_range[1].hex())
+            # if lsn_range[2] is not None:   # Test to see if there are any change records to process
+            #    lsn_from = str(lsn_range[2].hex())
+            #    lsn_to   = str(lsn_range[3].hex())
+
+               if lsn_from <= state_last_lsn:
+                  LOGGER.info("The last lsn processed as per the state file %s, minimum available lsn for extract table %s, and the maximum lsn is %s.", state_last_lsn, lsn_from, lsn_to)
+               else:
+                  raise Exception("Error {}.{}: CDC changes have expired, the minimum lsn is {}, the last processed lsn is {}. Recommend a full load as there may be missing data.".format(schema_name, table_name, lsn_from, state_last_lsn ))                
+
+               select_sql = """DECLARE @from_lsn binary (10), @to_lsn binary (10)
+                    
+                               SET @from_lsn = sys.fn_cdc_increment_lsn({})
+                               SET @to_lsn = {}
+
+                               SELECT {}
+                                   ,case __$operation
+                                       when 2 then 'I'
+                                       when 4 then 'U'
+                                       when 1 then 'D'
+                                   end _sdc_operation_type
+                                   , sys.fn_cdc_map_lsn_to_time(__$start_lsn) _sdc_lsn_commit_timestamp
+                                   , case __$operation
+                                       when 1 then sys.fn_cdc_map_lsn_to_time(__$start_lsn)
+                                       else null
+                                       end _sdc_lsn_deleted_at
+                                   , __$start_lsn _sdc_lsn_value
+                                   , __$seqval _sdc_lsn_seq_value 
+                                   , __$operation _sdc_lsn_operation
+                               FROM cdc.fn_cdc_get_all_changes_{}(@from_lsn, @to_lsn, 'all')
+                               ORDER BY __$start_lsn, __$seqval, __$operation
+                               ;""".format(py_bin_to_mssql(state_last_lsn), py_bin_to_mssql(lsn_to), ",".join(escaped_columns), schema_table )
+
+               params = {}
+
+               common.sync_query(
+                   cur, catalog_entry, state, select_sql, extended_columns, stream_version, params
+               )
+            
+               state = singer.write_bookmark(state, catalog_entry.tap_stream_id, 'lsn', lsn_to)
+               singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+
+    # clear max lsn value and last lsn fetched upon successful sync
+    singer.clear_bookmark(state, catalog_entry.tap_stream_id, "max_lsn_values")
+    singer.clear_bookmark(state, catalog_entry.tap_stream_id, "last_lsn_fetched")
+
+    singer.write_message(activate_version_message)


### PR DESCRIPTION
This pull request build on top of https://github.com/wintersrd/pipelinewise-tap-mssql/pull/24 . It is a superset of pull request 24.

This larger change introduces LOG_BASED / Change Data Capture (CDC) replication for pipelinewise-tap-mssql.

Features Include:

 Support for MS SQL Server Change Data Capture (CDC) / LOG_BASED replication
 Additional documentation (MS_CDC_SETUP.md) which describes how to enable CDC replication on SQL Server
 Updated README.md for using LOG_BASED replication
 Automatic initial load for tables when using LOG_BASED. After the initial load only changes (Inserts, Update, or Deletes) will be replicated from the last point of replication using the SQL Server LSN as a point of reference.
 Current replication LSN is emitted as a state message to pick-up from the point of the last run
Note: This change does not support change tracking which is an older MS SQL Server replication technology. Change Data Capture is a more efficient and complete solution for incremental replication.

Note: While this change has been well tested and used, it comes with no warranties on guaranteed delivery and zero data loss in replication. It is recommend to test this well and ensure there is a frequent replication within the set archive policy for CDC logs.