### PR TITLE
Fix confusing error message

### DIFF
--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -657,7 +657,7 @@ def sync_non_cdc_streams(mssql_conn, non_cdc_catalog, config, state):
                 do_sync_historical_log(mssql_conn, config, catalog_entry, state, columns)
             else:
                 raise Exception(
-                    "only INCREMENTAL, LOG_BASED and FULL TABLE replication methods are supported"
+                    "only INCREMENTAL, LOG_BASED and FULL_TABLE replication methods are supported"
                 )
 
     state = singer.set_currently_syncing(state, None)


### PR DESCRIPTION
Error message replication method `FULL TABLE` does not reflect the logically matched value of `FULL_TABLE`. Very minor fix to prevent confusion. :slightly_smiling_face:

---

Context: https://meltano.slack.com/archives/CMN8HELB0/p1688130547416099