### PR TITLE
Supporting Datetimeoffset. Bug Fix: Tinyint and Datetime2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# tap-mssql 2.2.0 2023-08-23
+
+This feature increases support for SQL Datatypes.
+
+* Adds support for datetimeoffset - https://github.com/wintersrd/pipelinewise-tap-mssql/issues/50
+* Resolves issue with datetime2 rounding with high precision timestamps https://github.com/wintersrd/pipelinewise-tap-mssql/issues/51
+* Resolves the max and min range for tinyints. The current min and max are correct for MariaDB and MySQL only. MSSQL Server only supports
+positive integers (unsigned tinyint). https://github.com/wintersrd/pipelinewise-tap-mssql/issues/2
+
 # tap-mssql 2.1.0 2023-08-01
 
 This is a number of new enhancements to extend capability and resolving a few bugs.

--- a/README.md
+++ b/README.md
@@ -492,6 +492,27 @@ This invocation extracts any data since (and including) the
 
 Based on Stitch documentation
 
+## Data Types
+
+The json output by this tap should be JSON schema compliant and also conform to the Singer Framework standard.
+
+Noted: Below is some examples of the data transformation to present data in a standard manner for Singer Targets.
+
+A special note for `datetime2` and `datetimeoffsets` MS SQL Server datatypes.
+
+For `datetime2`, it as a naïve datetime timestamp with no concept of an offset, `datetime2` supports nanoseconds with up to seven decimal places. With `datetimeoffset` datatypes, the data is normalized to UTC i.e. taking the offset as it is in MSSQL Server and converting it to a UTC so it is agnostic to the target platform - anything with a datetimeoffset can be cast into local time in the target.
+
+To work-around issues with the PYMSSQL driver, the conversion takes place on the SQL Server source to ensure there is no loss of precision leading to errors as a result of rounding.
+
+|SQL DataType|Example Value|Min|Max| JSON Format| JSON Type |Example Result|
+|-----------------|------------------------|-------------------------|-----------------------------|------------------------|------------------------|-----------------------|
+| tinyint  | 254  | 0  | 255   | | integer   | 254  |
+| smallint  | -32768  | -32768  | 32767   | | integer   | -32768  |
+| int  | -2147483648  | -2147483648  | 2147483647   | | integer   | -2147483648  |
+| bigint  | -9223372036854775808  | -9223372036854775808  | 9223372036854775807   | | integer   | -9223372036854775808  |
+| datetime2 | 9999-12-31 23:59:59.9999999 | | | date-time |  string | 9999-12-31 23:59:59.9999999 |
+| datetimeoffset | 2023-08-22 08:24:32.1277000 +10:00 | | | date-time |  string | 2023-08-21T22:24:32.1277000Z |
+
 ## Build Instructions
 
 This section dives into basic commands to build `tap-mssql` if an alteration is made to the code.

--- a/README.md
+++ b/README.md
@@ -496,25 +496,15 @@ Based on Stitch documentation
 
 This section dives into basic commands to build `tap-mssql` if an alteration is made to the code.
 
-### Setup Tools
-
-You may need a copy of setup tools or an up to date version of setup tools to build `tap-mssql`
-
-To do this follow these instructions.
-
-```bash
-  # Ensure you have first sourced the python virtual environment e.g.
-  source venv/bin/activate
-
-  python -m pip install --upgrade setuptools
-```
-
 ### To build the tap
 
 Run the following command each time you need to rebuild the tap.
 
 ```bash
-$ python setup.py install
+  python3 -m venv venv
+  . venv/bin/activate
+  pip install --upgrade pip
+  pip install .
 ```
 
 ### Debugging in Visual Studio Code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-mssql"
-version = "2.1.1"
+version = "2.2.0"
 description = "A pipelinewise compatible tap for connecting Microsoft SQL Server"
 authors = ["Rob Winters <wintersrd@gmail.com>"]
 license = "GNU Affero"

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -66,7 +66,7 @@ FLOAT_TYPES = set(["float", "double", "real"])
 
 DECIMAL_TYPES = set(["decimal", "number", "money", "smallmoney", "numeric"])
 
-DATETIME_TYPES = set(["datetime2", "datetime", "timestamp", "smalldatetime"])
+DATETIME_TYPES = set(["datetime2", "datetime", "datetimeoffset", "timestamp", "smalldatetime"])
 
 DATE_TYPES = set(["date"])
 
@@ -105,8 +105,12 @@ def schema_for_column(c, config):
     elif data_type in BYTES_FOR_INTEGER_TYPE:
         result.type = ["null", "integer"]
         bits = BYTES_FOR_INTEGER_TYPE[data_type] * 8
-        result.minimum = 0 - 2 ** (bits - 1)
-        result.maximum = 2 ** (bits - 1) - 1
+        if data_type == 'tinyint':
+            result.minimum = 0
+            result.maximum = 255
+        else:
+            result.minimum = 0 - 2 ** (bits - 1)
+            result.maximum = 2 ** (bits - 1) - 1
 
     elif data_type in FLOAT_TYPES:
         if use_singer_decimal:
@@ -135,6 +139,7 @@ def schema_for_column(c, config):
             result.maxLength = c.character_maximum_length
 
     elif data_type in DATETIME_TYPES:
+        result.additionalProperties = {"sql_data_type": data_type}
         result.type = ["null", "string"]
         result.format = "date-time"
 

--- a/tap_mssql/sync_strategies/log_based.py
+++ b/tap_mssql/sync_strategies/log_based.py
@@ -194,7 +194,7 @@ def sync_historic_table(mssql_conn, config, catalog_entry, state, columns, strea
     with connect_with_backoff(mssql_conn) as open_conn:
         with open_conn.cursor() as cur:
 
-            escaped_columns = [common.escape(c) for c in columns]
+            escaped_columns = map(lambda c: common.prepare_columns_sql(catalog_entry, c), columns)
             table_name = catalog_entry.table
             schema_name = common.get_database_name(catalog_entry)
 
@@ -288,7 +288,7 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
 
             state_last_lsn = singer.get_bookmark(state, catalog_entry.tap_stream_id, "lsn")
 
-            escaped_columns = [common.escape(c) for c in columns]
+            escaped_columns = map(lambda c: common.prepare_columns_sql(catalog_entry, c), columns)
             table_name = catalog_entry.table
             schema_name = common.get_database_name(catalog_entry)
             schema_table = schema_name + "_" + table_name

--- a/tests/test_tap_mssql.py
+++ b/tests/test_tap_mssql.py
@@ -117,7 +117,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_tinyint(self):
         self.assertEqual(
             self.schema.properties["c_tinyint"],
-            Schema(["null", "integer"], inclusion="available", minimum=-128, maximum=127),
+            Schema(["null", "integer"], inclusion="available", minimum=0, maximum=255),
         )
         # self.assertEqual(
         #     self.get_metadata_for_column("c_tinyint"),


### PR DESCRIPTION
# tap-mssql 2.2.0 2023-08-23

This feature increases support for SQL Datatypes.

* Adds support for datetimeoffset - https://github.com/wintersrd/pipelinewise-tap-mssql/issues/50
* Resolves issue with datetime2 rounding with high precision timestamps https://github.com/wintersrd/pipelinewise-tap-mssql/issues/51
* Resolves the max and min range for tinyints. The current min and max are correct for MariaDB and MySQL only. MSSQL Server only supports
positive integers (unsigned tinyint). https://github.com/wintersrd/pipelinewise-tap-mssql/issues/2

Please Note: For `datetimeoffset` the output follows the Singer Framework recommendation - that is the offset is emitted in UTC format.