### PR TITLE
Supporting different SQL Server info schemas - Singer Decimal

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.2
+current_version = 2.2.3
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# tap-mssql 2.2.3 2024-02-26
+
+* Bug Fix. Enhancing singer-decimal output for numeric data to correctly output the correct datatype - string and precision.
+
 # tap-mssql 2.2.1 2023-10-30
 
 * Bug Fix. Removing test code which slipped into the release, and adjusting offending code with correct dynamic column name.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-mssql"
-version = "2.2.2"
+version = "2.2.3"
 description = "A pipelinewise compatible tap for connecting Microsoft SQL Server"
 authors = ["Rob Winters <wintersrd@gmail.com>"]
 license = "GNU Affero"

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -122,9 +122,9 @@ def schema_for_column(c, config):
 
     elif data_type in DECIMAL_TYPES:
         if use_singer_decimal:
-            result.type = ["null","number"]
+            result.type = ["null","number","string"]
             result.format = "singer.decimal"
-            result.additionalProperties = {"scale_precision": f"({c.character_maximum_length},{c.numeric_scale})"}
+            result.additionalProperties = {"scale_precision": f"({c.character_maximum_length or c.numeric_precision},{c.numeric_scale})"}
         else:
             result.type = ["null", "number"]
             result.multipleOf = 10 ** (0 - c.numeric_scale)


### PR DESCRIPTION
Overview:
The output of Singer Decimal is a string for a numeric column (with hints about the precision and scale) so it can be reconstructed correctly in the target. Singer Decimal - that is output as a string is done to avoid rounding issue in Python and the Singer Framework. It is a safer method as there is no loss in precision.

Problem:

1. The output of Singer Decimal is a string for a numeric based columns. The old code did not support string as a value data_type when Singer Decimal was enabled. This cause JSON Schema validation to fail.
2. The precision is not being correctly determined in later versions of SQL Server. The results from the SQL Server Information Schema can vary from database version to database version. In earlier database versions a int / decimal will have the value populated in the `character_maximum_length` in later database versions the maximum allow size in the `numeric_precision` field.

Ingestion into target-jsonl would fail due to schema validation failing. Loading into a custom Target Snowflake would fail due to the precision being set to `None` which is an invalid precision.

Changes:

1. Add 'string' to the list of data types which can be outputted when singer decimal is enabled.
2. Try to obtain the precision from the `character_maximum_length` field in the information schema. If the result is `None` then obtain the precision from the `numeric_precision` field.

Results:

Target JSONL

![image](https://github.com/wintersrd/pipelinewise-tap-mssql/assets/84364906/531bdab2-f8ff-46a0-b2c8-cdd43f017a15)

Target Snowflake

![image](https://github.com/wintersrd/pipelinewise-tap-mssql/assets/84364906/e90aa07a-4809-45b2-b48b-a7b87d49b12c)
![image](https://github.com/wintersrd/pipelinewise-tap-mssql/assets/84364906/02381f96-10af-471e-bb68-96a21949da2c)
