### PR TITLE
fix: GitHub Actions - pin poetry to 1.8.* and remove pip install in tox.ini

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.2
+current_version = 2.2.2
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.9.13
 
       - name: Install Poetry
-        run: pip install poetry>=1.4.2
+        run: pip install --upgrade pip "poetry==1.8.*"
 
       - name: Cache Poetry virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.9.13
 
       - name: Install Poetry
-        run: pip install poetry
+        run: pip install poetry>=1.4.2
 
       - name: Cache Poetry virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.9.13
 
       - name: Install Poetry
-        run: pip install poetry==1.4.2
+        run: pip install poetry
 
       - name: Cache Poetry virtualenv
         uses: actions/cache@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-mssql"
-version = "2.2.1"
+version = "2.2.2"
 description = "A pipelinewise compatible tap for connecting Microsoft SQL Server"
 authors = ["Rob Winters <wintersrd@gmail.com>"]
 license = "GNU Affero"
@@ -19,7 +19,7 @@ attrs = ">=16.3.0"
 pendulum = ">=1.2.0"
 singer-python = "5.9.0"
 # pymssql==2.2.8 broken: https://github.com/pymssql/pymssql/issues/833
-pymssql = ">=2.1.2,!=2.2.8"
+pymssql = ">=2.1.4,!=2.2.8"
 backoff = ">=1.8.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ bumpversion = "^0.6.0"
 tox = "^3.28.0"
 
 [build-system]
-requires = ["poetry==1.4.2"]
+requires = ["poetry>=1.4.2"]
 build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ bumpversion = "^0.6.0"
 tox = "^3.28.0"
 
 [build-system]
-requires = ["poetry>=1.4.2"]
+requires = ["poetry==1.8.*"]
 build-backend = "poetry.masonry.api"

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ whitelist_externals =
     poetry
 commands =
     echo {env:APPDATA}
-    pip install --upgrade pip poetry==1.4.2 virtualenv
+    pip install --upgrade pip poetry virtualenv
     poetry install
     poetry run pytest --cov-report=xml:coverage-reports/coverage.xml --cov-report term-missing tests/test_tap_mssql.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ whitelist_externals =
     poetry
 commands =
     echo {env:APPDATA}
-    pip install --upgrade pip poetry virtualenv
+    pip install --upgrade pip "poetry==1.8.*" virtualenv
     poetry install
     poetry run pytest --cov-report=xml:coverage-reports/coverage.xml --cov-report term-missing tests/test_tap_mssql.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ whitelist_externals =
     poetry
 commands =
     echo {env:APPDATA}
-    pip install --upgrade pip "poetry==1.8.*" virtualenv
+    
     poetry install
     poetry run pytest --cov-report=xml:coverage-reports/coverage.xml --cov-report term-missing tests/test_tap_mssql.py
 


### PR DESCRIPTION
Duplicated pip install in tox.ini appeared to be installing poetry again while trying to run tests - reference for that hypothesis here: https://github.com/python-poetry/poetry/issues/8044

No new release required as only the GitHub actions has been updated - no change to tap functionality.