### PR TITLE
fix: Schema is not retaining the correct column order

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.0
+current_version = 2.3.1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# tap-mssql 2.3.1 2024-07-22
+
+* Bug Fix. Issue #62 - change to column selection using lists instead of sets to preserve column ordering
+
 # tap-mssql 2.3.0 2024-04-18
 
 * Bug Fix. Change pendulum DateTime type to datetime.datetime as pymssql 2.3.0 is no longer compatible with query parameters as pendulum DateTime (https://github.com/pymssql/pymssql/issues/889)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-mssql"
-version = "2.3.0"
+version = "2.3.1"
 description = "A pipelinewise compatible tap for connecting Microsoft SQL Server"
 authors = ["Rob Winters <wintersrd@gmail.com>"]
 license = "GNU Affero"

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -368,7 +368,7 @@ def desired_columns(selected : list, table_schema):
             not_selected_but_automatic,
         )
 
-    desired = [c for c in selected if c in available or c in automatic]
+    desired = [c for c in all_columns if (c in available and c in selected) or c in automatic]
 
     return list(dict.fromkeys(desired))
 

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -348,7 +348,7 @@ def desired_columns(selected : list, table_schema):
     ]
 
     if unknown:
-        raise Exception("Unknown inclusions " + unknown)
+        raise Exception(f"Unknown inclusions: {unknown}")
 
     selected_but_unsupported = [c for c in selected if c in unsupported]
     if selected_but_unsupported:

--- a/tests/test_tap_mssql.py
+++ b/tests/test_tap_mssql.py
@@ -264,7 +264,7 @@ class TestTypeMapping(unittest.TestCase):
 
 class TestSelectsAppropriateColumns(unittest.TestCase):
     def runTest(self):
-        selected_cols = set(["a", "a1", "a2", "b", "d"])
+        selected_cols = ["a", "a1", "a2", "b", "d"]
         table_schema = Schema(
             type="object",
             properties={
@@ -280,8 +280,10 @@ class TestSelectsAppropriateColumns(unittest.TestCase):
         got_cols = tap_mssql.desired_columns(selected_cols, table_schema)
 
         self.assertEqual(
-            list(got_cols), ["a", "a1", "a2", "c"], "Keep automatic as well as selected, available columns. Ordered correctly."
+            got_cols, ["a", "a1", "a2", "c"], "Keep automatic as well as selected, available columns. Ordered correctly."
         )
+
+#TODO: Add further tests on the desired_columns function - e.g. no duplicates, invalid inclusion
 
 
 class TestSchemaMessages(unittest.TestCase):

--- a/tests/test_tap_mssql.py
+++ b/tests/test_tap_mssql.py
@@ -264,7 +264,7 @@ class TestTypeMapping(unittest.TestCase):
 
 class TestSelectsAppropriateColumns(unittest.TestCase):
     def runTest(self):
-        selected_cols = ["a", "a1", "a2", "b", "d"]
+        selected_cols = ["a", "a", "a1", "a2", "b", "d"]
         table_schema = Schema(
             type="object",
             properties={
@@ -282,6 +282,19 @@ class TestSelectsAppropriateColumns(unittest.TestCase):
         self.assertEqual(
             got_cols, ["a", "a1", "a2", "c"], "Keep automatic as well as selected, available columns. Ordered correctly."
         )
+
+class TestInvalidInclusion(unittest.TestCase):
+    def runTest(self):
+        selected_cols = ["a", "e"]
+        table_schema = Schema(
+            type="object",
+            properties={
+                "a": Schema(None, inclusion="available"),
+                "e": Schema(None, inclusion="invalid"),
+            },
+        )
+
+        self.assertRaises(Exception, tap_mssql.desired_columns(selected_cols, table_schema))
 
 #TODO: Add further tests on the desired_columns function - e.g. no duplicates, invalid inclusion
 

--- a/tests/test_tap_mssql.py
+++ b/tests/test_tap_mssql.py
@@ -264,7 +264,7 @@ class TestTypeMapping(unittest.TestCase):
 
 class TestSelectsAppropriateColumns(unittest.TestCase):
     def runTest(self):
-        selected_cols = ["a", "a1", "a2", "b", "d"]
+        selected_cols = set(["a", "a1", "a2", "b", "d"])
         table_schema = Schema(
             type="object",
             properties={

--- a/tests/test_tap_mssql.py
+++ b/tests/test_tap_mssql.py
@@ -294,10 +294,7 @@ class TestInvalidInclusion(unittest.TestCase):
             },
         )
 
-        self.assertRaises(Exception, tap_mssql.desired_columns(selected_cols, table_schema))
-
-#TODO: Add further tests on the desired_columns function - e.g. no duplicates, invalid inclusion
-
+        self.assertRaises(Exception, tap_mssql.desired_columns, selected_cols, table_schema)
 
 class TestSchemaMessages(unittest.TestCase):
     def runTest(self):

--- a/tests/test_tap_mssql.py
+++ b/tests/test_tap_mssql.py
@@ -269,6 +269,9 @@ class TestSelectsAppropriateColumns(unittest.TestCase):
             type="object",
             properties={
                 "a": Schema(None, inclusion="available"),
+                "a1": Schema(None, inclusion="available"),
+                "a2": Schema(None, inclusion="available"),
+                "a3": Schema(None, inclusion="available"),
                 "b": Schema(None, inclusion="unsupported"),
                 "c": Schema(None, inclusion="automatic"),
             },
@@ -277,7 +280,7 @@ class TestSelectsAppropriateColumns(unittest.TestCase):
         got_cols = tap_mssql.desired_columns(selected_cols, table_schema)
 
         self.assertEqual(
-            got_cols, set(["a", "c"]), "Keep automatic as well as selected, available columns."
+            list(got_cols), ["a", "a1", "a2", "a3", "c"], "Keep automatic as well as selected, available columns. Ordered correctly."
         )
 
 

--- a/tests/test_tap_mssql.py
+++ b/tests/test_tap_mssql.py
@@ -264,7 +264,7 @@ class TestTypeMapping(unittest.TestCase):
 
 class TestSelectsAppropriateColumns(unittest.TestCase):
     def runTest(self):
-        selected_cols = set(["a", "b", "d"])
+        selected_cols = ["a", "a1", "a2", "b", "d"]
         table_schema = Schema(
             type="object",
             properties={
@@ -280,7 +280,7 @@ class TestSelectsAppropriateColumns(unittest.TestCase):
         got_cols = tap_mssql.desired_columns(selected_cols, table_schema)
 
         self.assertEqual(
-            list(got_cols), ["a", "a1", "a2", "a3", "c"], "Keep automatic as well as selected, available columns. Ordered correctly."
+            list(got_cols), ["a", "a1", "a2", "c"], "Keep automatic as well as selected, available columns. Ordered correctly."
         )
 
 


### PR DESCRIPTION
Fixes #62 by refactoring the `desired_columns` function to use lists instead of sets as they preserve order. List comprehensions are used to filter the lists rather than a loop. Operations such as intersection, difference and union are also replaced with list comprehensions.

Also includes modifications to the existing `TestSelectsAppropriateColumns`:

* Adds more columns to strengthen proof that ordering is preserved
* Assertion changed to compare two lists, will fail if they are not in the same order
* Added a duplicate column to the select list

Adds new test `TestInvalidInclusion` which tests that an exception is raised when an `inclusion` value of "invalid" is supplied, which is not one of the valid values:
* automatic
* available
* unsupported
