### PR TITLE
Bug/fix replicate table primary keys

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.6.1
+current_version = 2.6.2
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# tap-mssql 2.6.2 2024-10-09
+* Resolving issue when a table has a primary key and unique key. Both unique and primary key
+  columns were being identified as the primary key for the target table. Prioritising the
+  primary key first, and unique key secondary if there is no primary key.
+
 # tap-mssql 2.6.1 2024-10-09
 * Resolving issue with call get the prior LSN number (passing in unescaped table).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-mssql"
-version = "2.6.1"
+version = "2.6.2"
 description = "A pipelinewise compatible tap for connecting Microsoft SQL Server"
 authors = ["Rob Winters <wintersrd@gmail.com>"]
 license = "GNU Affero"


### PR DESCRIPTION
Resolving issue when a table has a primary key and unique key. Both unique and primary key columns were being identified as the primary key for the target table. Prioritising the primary key first, and unique key secondary if there is no primary key.

The code prior to the fix is overstating what the primary key is.

This  change resolves #87 