### PR TITLE
Add 'ntext' type support.

### DIFF
--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -51,6 +51,7 @@ STRING_TYPES = set(
         "uniqueidentifier",
         "nvarchar",
         "nchar",
+        "ntext"
     ]
 )
 


### PR DESCRIPTION
Add support for syncing columns of type 'ntext'.

Simply adds "ntext" to the STRING_TYPES array.