### PR TITLE
Adding support for ntext datatype

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.6.4
+current_version = 2.6.5
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+# tap-mssql 2.6.5 2024-10-24
+* Adding support for ntext to list of valid STRING_TYPES.
+
 # tap-mssql 2.6.4 2024-10-24
 * Update to handle `timestamp` (not a datetime value, a [deprecated](https://learn.microsoft.com/en-us/sql/t-sql/data-types/rowversion-transact-sql?view=sql-server-ver16#remarks) synonym of internal `rowversion`) as string
 * Add tests for incremental syncing using a `timestamp` column as `replication-key`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-mssql"
-version = "2.6.4"
+version = "2.6.5"
 description = "A pipelinewise compatible tap for connecting Microsoft SQL Server"
 authors = ["Rob Winters <wintersrd@gmail.com>"]
 license = "GNU Affero"

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -51,6 +51,7 @@ STRING_TYPES = set(
         "uniqueidentifier",
         "nvarchar",
         "nchar",
+        "ntext",
     ]
 )
 


### PR DESCRIPTION
Adding support for the deprecated SQL Server ntext datatype as some database have this older datatype.

This replaces https://github.com/wintersrd/pipelinewise-tap-mssql/pull/92 because of the need to version the release.