### PR TITLE
_sdc_deleted_at compatibility

### DIFF
--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -52,6 +52,7 @@ STRING_TYPES = set(
         "nvarchar",
         "nchar",
         "ntext",
+        "xml",
     ]
 )
 


### PR DESCRIPTION
#### background

We've seen that targets such as [Matatika/target-postgres](https://github.com/Matatika/pipelinewise-target-postgres) support 'hard_delete' using the `_sdc_deleted_at` column.

Unfortunately there is no standard for this 'hard_delete' approach.  Although this target understands and processes _sdc_deleted_at, other targets do not.

e.g. tap-postgres emits _sdc_deleted_at [tap-postgres/tap_postgres/sync_strategies/logical_replication.py at master · singer-io/tap-postgres](https://github.com/singer-io/tap-postgres/blob/master/tap_postgres/sync_strategies/logical_replication.py)

Whereas, this tap-mssql only emits `_sdc_lsn_deleted_at`:  [LOG_BASED replication seems to wipe target table before loading · Issue #71 · wintersrd/pipelinewise-tap-mssql](https://github.com/wintersrd/pipelinewise-tap-mssql/issues/71)


#### proposed solution

Emit `_sdc_deleted_at` in addition to the `_lsn` extended columns

[pipelinewise-tap-mssql/tap_mssql/sync_strategies/log_based.py at afa5b066cea060640a149365784e3747a59a877a · Matatika/pipelinewise-tap-mssql](https://github.com/Matatika/pipelinewise-tap-mssql/blob/afa5b066cea060640a149365784e3747a59a877a/tap_mssql/sync_strategies/log_based.py#L176)

And adding columns to the catalog as well

[GitHub](https://github.com/search?q=repo%3AMatatika%2Fpipelinewise-tap-mssql+_sdc_lsn_deleted_at&type=code) [pipelinewise-tap-mssql/tap_mssql/sync_strategies/log_based.py at afa5b066cea060640a149365784e3747a59a877a · Matatika/pipelinewise-tap-mssql](https://github.com/Matatika/pipelinewise-tap-mssql/blob/afa5b066cea060640a149365784e3747a59a877a/tap_mssql/sync_strategies/log_based.py#L123)  and [pipelinewise-tap-mssql/tap_mssql/sync_strategies/log_based.py at afa5b066cea060640a149365784e3747a59a877a · Matatika/pipelinewise-tap-mssql](https://github.com/Matatika/pipelinewise-tap-mssql/blob/afa5b066cea060640a149365784e3747a59a877a/tap_mssql/sync_strategies/log_based.py#L176)

